### PR TITLE
The address details were inconsistently being utf8 encoded. Countries we...

### DIFF
--- a/src/SpeckAddress/Form/AddressFactory.php
+++ b/src/SpeckAddress/Form/AddressFactory.php
@@ -92,7 +92,7 @@ class AddressFactory implements FactoryInterface
         $countryOptions[""] = "";
         foreach ($countries as $c) {
             $countryOptions[] = array(
-                'label' => utf8_encode($c['country']),
+                'label' => $c['country'],
                 'value' => $c['country_code'],
                 'weight' => isset($weights[$c['country_code']]) ? $weights[$c['country_code']] : 1,
                 'alt-spelling' => isset($spelling[$c['country_code']]) ? $spelling[$c['country_code']] : '',


### PR DESCRIPTION
...re but provinces weren't. If the databse is set to utf8 and the database connection is set to utf8 we do not need to encode the data as well and was causing display issues.